### PR TITLE
fix: webdav arguments are passed in wrong order

### DIFF
--- a/remotefs-fuse-cli/src/cli/webdav.rs
+++ b/remotefs-fuse-cli/src/cli/webdav.rs
@@ -18,6 +18,6 @@ pub struct WebdavArgs {
 
 impl From<WebdavArgs> for WebDAVFs {
     fn from(args: WebdavArgs) -> Self {
-        WebDAVFs::new(&args.url, &args.username, &args.password)
+        WebDAVFs::new(&args.username, &args.password, &args.url)
     }
 }


### PR DESCRIPTION
WebDAV arguments are passed in the wrong order:

```rust
impl WebDAVFs {
    /// Create a new WebDAVFs instance
    pub fn new(username: &str, password: &str, url: &str) -> WebDAVFs {
        WebDAVFs {
            client: Client::init(username, password),
            url: url.to_string(),
            wrkdir: String::from("/"),
            connected: false,
        }
    }
```

The CLI calls it like this:

```rust
impl From<WebdavArgs> for WebDAVFs {
    fn from(args: WebdavArgs) -> Self {
        WebDAVFs::new(&args.url, &args.username, &args.password)
    }
}
```

This is clearly wrong, and results in the WebDAV CLI being unusable unless you switch up the name of arguments.